### PR TITLE
First client integration tests

### DIFF
--- a/client/src/client-ws.js
+++ b/client/src/client-ws.js
@@ -1,0 +1,26 @@
+/**
+ * In node.js we want to use the ws module for WebSocket. In the
+ * browser we can just use the native WebSocket. Here we adapt
+ * the browser's WebSocket interface to more closely match ws
+ * so that we can use either.
+ *
+ * This module gets used by browserify, see package.json
+ */
+
+global.WebSocket.on = global.WebSocket.on || function(event, listener) {
+  this.addEventListener(event, listener);
+};
+
+global.WebSocket.removeListener = global.WebSocket.removeListener || function(event, listener) {
+  this.removeEventListener(event, listener);
+};
+
+global.WebSocket.once = global.WebSocket.once || function(event, listener) {
+  var ws = this;
+  this.addEventListener(event, function onEvent() {
+    ws.removeEventListener(event, onEvent);
+    listener.apply(null, arguments);
+  });
+};
+
+module.exports = global.WebSocket;

--- a/client/src/sync.js
+++ b/client/src/sync.js
@@ -5,7 +5,8 @@ var SyncMessage = require( '../../lib/syncmessage' ),
     _fs,
     syncCallback,
     states = require('./sync-states'),
-    steps = require('./sync-steps');
+    steps = require('./sync-steps'),
+    WebSocket = require('ws');
 
 var syncSession = {
   state: states.CLOSED,
@@ -48,8 +49,6 @@ var syncSession = {
   })
 };
 
-
-
 function init(url, token, sync, fs, callback) {
   _sync = sync;
   _fs = fs;
@@ -65,7 +64,7 @@ function init(url, token, sync, fs, callback) {
     }
 
     if(data.is.response && data.is.authz) {
-      socket.removeEventListener('message', handleAuth);
+      socket.removeListener('message', handleAuth);
       syncSession.state = states.READY;
       syncSession.step = steps.SYNCED;
       socket.onmessage = function(data, flags) {

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
   "main": "./server/index.js",
   "browser": {
     "filer": "./node_modules/filer/dist/filer.js",
-    "request": "browser-request"
+    "request": "browser-request",
+    "ws": "./client/src/client-ws.js"
   }
 }

--- a/tests/unit/client-integration-tests.js
+++ b/tests/unit/client-integration-tests.js
@@ -1,0 +1,113 @@
+var expect = require('chai').expect;
+var util = require('../lib/util.js');
+var MakeDrive = require('../../client/src');
+var Filer = require('filer');
+
+describe('MakeDrive Client Tests', function(){
+  var provider;
+
+  beforeEach(function() {
+    provider = new Filer.FileSystem.providers.Memory(util.username());
+  });
+  afterEach(function() {
+    provider = null;
+  });
+
+  it('should have expected methods and properites', function() {
+    // Bits copied from Filer
+    expect(MakeDrive.Buffer).to.be.a.function;
+    expect(MakeDrive.Path).to.exist;
+    expect(MakeDrive.Path.normalize).to.be.a.function;
+    expect(MakeDrive.Errors).to.exist;
+
+    // MakeDrive.fs()
+    expect(MakeDrive.fs).to.be.a.function;
+    var fs = MakeDrive.fs({memory: true, manual: true});
+    var fs2 = MakeDrive.fs({memory: true, manual: true});
+    expect(fs).to.equal(fs2);
+
+    // MakeDrive.fs().sync property
+    expect(fs.sync).to.exist;
+    expect(fs.sync.on).to.be.a.function;
+    expect(fs.sync.off).to.be.a.function;
+    expect(fs.sync.connect).to.be.a.function;
+    expect(fs.sync.disconnect).to.be.a.function;
+    expect(fs.sync.sync).to.be.a.function;
+
+    // Sync States
+    expect(fs.sync.SYNC_DISCONNECTED).to.equal(0);
+    expect(fs.sync.SYNC_CONNECTING).to.equal(1);
+    expect(fs.sync.SYNC_CONNECTED).to.equal(2);
+    expect(fs.sync.SYNC_SYNCING).to.equal(3);
+    expect(fs.sync.SYNC_ERROR).to.equal(4);
+    expect(fs.sync.state).to.equal(fs.sync.SYNC_DISCONNECTED);
+  });
+
+  /**
+   * This test goes through the complete process of syncing with the server.
+   * It starts by connecting, then writes a file and tries to sync. The
+   * various sync events are observed, then it disconnects, and finally
+   * checks that the file was uploaded, and is available via the /p/ route.
+   */
+  it('should go through proper steps with connect(), request(), disconnect()', function(done) {
+    util.authenticatedConnection(function( err, result ) {
+      expect(err).not.to.exist;
+
+      var token = result.token;
+
+      var filename = '/file';
+      var fileData = 'data';
+
+      var fs = MakeDrive.fs({provider: provider, manual: true});
+      var sync = fs.sync;
+
+      var everSeenSyncing = false;
+      var everSeenCompleted = false;
+      var everSeenError = false;
+
+      sync.once('connected', function onConnected() {
+        expect(sync.state).to.equal(sync.SYNC_CONNECTED);
+
+        // Write a file and try to sync
+        fs.writeFile(filename, fileData, function(err) {
+          expect(err).not.to.exist;
+
+          sync.request('/');
+        });
+      });
+
+      sync.once('syncing', function onUpstreamSyncing() {
+        everSeenSyncing = sync.state;
+      });
+
+      sync.once('completed', function onUpstreamCompleted() {
+        everSeenCompleted = sync.state;
+        sync.disconnect();
+      });
+
+      sync.on('error', function onError(err) {
+        // Remember any errors we see--should be none
+        everSeenError = err;
+      });
+
+      sync.once('disconnected', function onDisconnected() {
+        expect(everSeenError).to.be.false;
+        if(everSeenError) {
+          console.error("Error was:", everSeenError);
+        }
+
+        expect(sync.state).to.equal(sync.SYNC_DISCONNECTED);
+        expect(everSeenSyncing).to.equal(sync.SYNC_SYNCING);
+        expect(everSeenCompleted).to.equal(sync.SYNC_CONNECTED);
+
+        // Confirm file was really uploaded using /p route
+        util.ensureFile(filename, fileData, result.jar, done);
+      });
+
+      expect(sync.state).to.equal(sync.SYNC_DISCONNECTED);
+      sync.connect(util.socketURL, token);
+      expect(sync.state).to.equal(sync.SYNC_CONNECTING);
+    });
+  });
+
+});


### PR DESCRIPTION
This is a working integration test.  I've changed a number of things, including:
- make MakeDrive client useable in node.js (with memory provider, and by swapping WebSocket/ws via browserify).
- add a way to turn off auto-sync'ing in the MakeDrive client, such that we can control when it happens in tests.

The test itself uses our authentication utils, gets a token, then sets up a MakeDrive fs instance, wires all the various listeners, writes a file, then tries to sync.  If all goes well, it moves through the various states, checking as it goes.

I'd like to write more tests, but it's currently not possible, since running this test after our other WebSocket tests, or writing more than one test like this (you can copy/paste it to see what I mean) will fail with `[Error: Current sync in progress! Try again later!]`.  This is hard to make sense of, since I'm using a different username (i.e., generated with a uuid), so nothing should be locked.  We need to solve that before I can move forward.
