### PR TITLE
Add /j/* route, refactor filer-www

### DIFF
--- a/server/lib/filer-www/index.js
+++ b/server/lib/filer-www/index.js
@@ -1,0 +1,50 @@
+/**
+ * A static web server on top of a Filer file system.
+ */
+
+var filesystem = require('../filesystem.js');
+var DefaultHandler = require('./default-handler.js');
+var JSONHandler = require('./json-handler.js');
+
+function FilerWebServer(username, res, options) {
+  options = options || {};
+
+  var fs = this.fs = filesystem.create({
+    keyPrefix: username,
+    name: username
+  });
+
+  // Pick the appropriate handler type to create
+  if(options.json) {
+    this.handler = new JSONHandler(fs, res);
+  } else {
+    this.handler = new DefaultHandler(fs, res);
+  }
+}
+
+/**
+ * Main entry-point for handling a path request.
+ * Each call should use a separate res object, since
+ * it will write headers + body.
+ */
+FilerWebServer.prototype.handle = function(path, res) {
+  var fs = this.fs;
+  var handler = this.handler;
+
+  fs.stat(path, function(err, stats) {
+    if(err) {
+      handler.handle404(path, res);
+      return;
+    }
+
+    // If this is a dir, show a dir listing
+    if(stats.isDirectory()) {
+      handler.handleDir(path, res);
+      return;
+    }
+
+    handler.handleFile(path, res);
+  });
+};
+
+module.exports = FilerWebServer;

--- a/server/lib/filer-www/json-handler.js
+++ b/server/lib/filer-www/json-handler.js
@@ -1,0 +1,82 @@
+/**
+ * A JSON Handler, for web APIs vs. browsers to consume
+ */
+var mime = require('mime');
+var Path = require('../../../lib/filer.js').Path;
+var version = require('../../../package.json').version;
+
+function write(content, res, status) {
+  status = status || 200;
+  res.jsonp(status, content);
+}
+
+/**
+ * Send an Apache-style 404
+ */
+function handle404(url, res) {
+  var json = {
+    error: {
+      code: 404,
+      message: 'The requested URL ' + url + ' was not found on this server.'
+    }
+  };
+  write(json, res, 404);
+}
+
+/**
+ * Send the raw file
+ */
+function handleFile(fs, path, res) {
+  var contentType = mime.lookup(path);
+  var encoding = mime.charsets.lookup(contentType) === "UTF-8" ? "utf8" : null;
+
+  fs.readFile(path, {encoding: encoding}, function(err, data) {
+    if(err) {
+      handle404(path, res);
+      return;
+    }
+
+    // If this is a Buffer, serialize it to a regular array
+    if(encoding === null) {
+      data = data.toJSON();
+    }
+
+    write(data, res);
+  });
+}
+
+/**
+ * Send recursive dir listing
+ */
+function handleDir(fs, path, res) {
+  var sh = fs.Shell();
+  var parent = Path.dirname(path);
+
+  sh.ls(path, {recursive: true}, function(err, listing) {
+    if(err) {
+      handle404(path, res);
+      return;
+    }
+    write(listing, res);
+  });
+}
+
+
+function JSONHandler(fs, res) {
+  this.fs = fs;
+  this.res = res;
+}
+
+JSONHandler.prototype.handle404 = function(path) {
+  handle404(path, this.res);
+};
+
+JSONHandler.prototype.handleDir = function(path) {
+  handleDir(this.fs, path, this.res);
+};
+
+JSONHandler.prototype.handleFile = function(path) {
+  handleFile(this.fs, path, this.res);
+};
+
+module.exports = JSONHandler;

--- a/server/lib/filer-www/util.js
+++ b/server/lib/filer-www/util.js
@@ -1,0 +1,49 @@
+function formatDate(d) {
+  // 20-Apr-2004 17:14
+  return d.getDay() + '-' +
+    d.getMonth() + '-' +
+    d.getFullYear() + ' ' +
+    d.getHours() + ':' +
+    d.getMinutes();
+}
+
+function formatSize(s) {
+  var units = ['', 'K', 'M'];
+  if(!s) {
+    return '-';
+  }
+  var i = (Math.floor(Math.log(s) / Math.log(1024)))|0;
+  return Math.round(s / Math.pow(1024, i), 2) + units[i];
+}
+
+function isMedia(ext) {
+  return ext === '.avi' ||
+    ext === '.mpeg' ||
+    ext === '.mp4' ||
+    ext === '.ogg' ||
+    ext === '.webm' ||
+    ext === '.mov' ||
+    ext === '.qt' ||
+    ext === '.divx' ||
+    ext === '.wmv' ||
+    ext === '.mp3' ||
+    ext === '.wav';
+}
+
+function isImage(ext) {
+  return ext === '.png' ||
+    ext === '.jpg' ||
+    ext === '.jpe' ||
+    ext === '.pjpg' ||
+    ext === '.jpeg'||
+    ext === '.gif' ||
+    ext === '.bmp' ||
+    ext === '.ico';
+}
+
+module.exports = {
+  formatDate: formatDate,
+  formatSize: formatSize,
+  isMedia: isMedia,
+  isImage: isImage
+};

--- a/tests/unit/client/multiple-file-sync.js
+++ b/tests/unit/client/multiple-file-sync.js
@@ -41,12 +41,8 @@ describe('MakeDrive Client - sync multiple files', function(){
 
       sync.once('completed', function onUpstreamCompleted() {
         // Make sure all 3 files made it to the server
-        util.ensureFile('/file1', layout['/file1'], result.jar, function() {
-          util.ensureFile('/file2', layout['/file2'], result.jar, function() {
-            util.ensureFile('/file3', layout['/file3'], result.jar, function() {
-              sync.disconnect();
-            });
-          });
+        util.ensureRemoteFilesystem(layout, result.jar, function() {
+          sync.disconnect();
         });
       });
 

--- a/tests/unit/util-tests.js
+++ b/tests/unit/util-tests.js
@@ -166,7 +166,7 @@ describe('Test util.js', function(){
           jar: result.jar
         }, function(err, res, body) {
           expect(err).not.to.exist;
-          expect(res.statusCode).to.equal(200);
+          expect(res.statusCode).to.equal(404);
           expect(body).to.match(/<title>404 Not Found<\/title>/);
           expect(body).to.match(/The requested URL \/no\/file\/here.html was not found on this server./);
           done();


### PR DESCRIPTION
I wanted to make it easier to write tests for the server filesystem from the client side.  I've created a new `/j/*` route, which is like the `/p/*` route but returns JSON instead of HTML.

I still want to add some tests for this, but will wait for @sedge to land his lock code, since he's moving tests around.
