### PR TITLE
Pass withCredentials to request

### DIFF
--- a/client/src/index.js
+++ b/client/src/index.js
@@ -240,7 +240,8 @@ function createFS(options) {
       request({
         url: apiSync,
         method: 'GET',
-        json: true
+        json: true,
+        withCredentials: true
       }, function(err, msg, body) {
         var statusCode;
         var error;


### PR DESCRIPTION
This got removed, and it breaks in browser with CORS.  Browser-request needs to get it from the options object.
