### PR TITLE
Fixed #117 - Error handling for disconnect/connect

### DIFF
--- a/client/src/index.js
+++ b/client/src/index.js
@@ -188,7 +188,7 @@ function createFS(options) {
     // Bail if we're already connected
     if(sync.state !== sync.SYNC_DISCONNECTED &&
        sync.state !== sync.ERROR) {
-      // TODO: https://github.com/mozilla/makedrive/issues/117
+      console.error("MakeDrive: Attempted to connect to \"" + url + "\", but a connection already exists!");
       return;
     }
 
@@ -313,7 +313,7 @@ function createFS(options) {
     // Bail if we're not already connected
     if(sync.state === sync.SYNC_DISCONNECTED ||
        sync.state === sync.ERROR) {
-      // TODO: https://github.com/mozilla/makedrive/issues/117
+      console.error("MakeDrive: Attempted to disconnect, but no server connection exists!");
       return;
     }
 


### PR DESCRIPTION
MakeDrive.js silently errored if `sync.connect()` was called when already connected, or `sync.disconnect()` was called when no connection existed.
