### PR TITLE
Allows non-existent directory path to be provided as the sync-path

### DIFF
--- a/lib/rsync.js
+++ b/lib/rsync.js
@@ -494,29 +494,28 @@ rsync.checksums = function(fs, path, srcList, options, callback) {
 
   function getDirChecksums(entry, callback) {
     var nodeChecksum = { path: entry.path };
+    var dirPath = getDirPath(path, entry.path);
+    var absPath = Path.join(dirPath, entry.path);
 
-    // Directory
-    if(options.recursive && entry.type === 'DIRECTORY') {
-      checksumsForDir(nodeChecksum, entry, callback);
-    }
-    // File or Link
-    else {
-      var dirPath = getDirPath(path, entry.path);
-      var absPath = Path.join(dirPath, entry.path);
+    // Create any parent directories that do not exist
+    fs.Shell().mkdirp(dirPath, function(err) {
+      if(err && err.code !== 'EEXIST') {
+        return callback(err);
+      }
 
-      // Create any parent directories that do not exist
-      fs.mkdir(dirPath, function(err) {
-        if(err && err.code !== 'EEXIST') {
-          return callback(err);
-        }
-
+      // Directory
+      if(options.recursive && entry.type === 'DIRECTORY') {
+        checksumsForDir(nodeChecksum, entry, callback);
+      }
+      // File or Link
+      else {
         if(entry.type === 'FILE' || !options.links) {
           checksumsForFile(nodeChecksum, entry, dirPath, absPath, callback);
         } else if(entry.type === 'SYMLINK'){
           checksumsForLink(nodeChecksum, entry, dirPath, absPath, callback);
         }
-      });
-    }
+      }
+    });
   }
 
   async.eachSeries(srcList, getDirChecksums, function(err) {

--- a/tests/unit/rsync-tests.js
+++ b/tests/unit/rsync-tests.js
@@ -1605,5 +1605,42 @@ describe('[Rsync Verification Tests]', function() {
         });
       });
     });
+
+    it('should create a non-existent directory if the directory path is used to sync', function (done) {
+      fs.mkdir('/dir', function (err) {
+        expect(err).to.not.exist;
+        fs.mkdir('/dir/dir2', function (err) {
+          expect(err).to.not.exist;
+          rsync.sourceList(fs, '/dir', OPTION_REC_SIZE, function (err, srcList) {
+            expect(err).to.not.exist;
+            expect(srcList).to.exist;
+            rsync.checksums(fs2, '/dir', srcList, OPTION_REC_SIZE, function (err, checksums) {
+              expect(err).to.not.exist;
+              expect(checksums).to.exist;
+              rsync.diff(fs, '/dir', checksums, OPTION_REC_SIZE, function (err, diffs) {
+                expect(err).to.not.exist;
+                expect(diffs).to.exist;
+                rsync.patch(fs2, '/dir', diffs, OPTION_REC_SIZE, function (err, paths) {
+                  expect(err).to.not.exist;
+                  expect(paths).to.exist;
+                  expect(paths.synced).to.have.members(['/dir/dir2']);
+                  fs2.stat('/dir', function (err, stats) {
+                    expect(err).to.not.exist;
+                    expect(stats).to.exist;
+                    expect(stats.isDirectory()).to.be.true;
+                    fs2.stat('/dir/dir2', function (err, stats) {
+                      expect(err).to.not.exist;
+                      expect(stats).to.exist;
+                      expect(stats.isDirectory()).to.be.true;
+                      done();
+                    });
+                  });
+                });
+              });
+            });
+          });
+        });
+      });
+    });
   });
 });


### PR DESCRIPTION
Fixed Issue #197: Rsync should create directory if a directory path is provided and it does not exist
