### PR TITLE
Reverted publishing changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,11 +94,7 @@
     "supertest": "0.13.x",
     "time-grunt": "^0.4.0"
   },
-  "main": "./makedrive.js",
-  "files": [
-    "./client/dist/makedrive.js",
-    "./client/dist/makedrive.min.js"
-  ],
+  "main": "./server/index.js",
   "browser": {
     "filer": "./node_modules/filer/dist/filer.js",
     "request": "browser-request",


### PR DESCRIPTION
We tried to have MakeDrive published on NPM as a client package, containing only the client-side library's distribution files. This broke installation, since we weren't including the Gruntfile and bower.json files that our NPM post-install script relied on.
