### PR TITLE
Remove crypto-js, which is unused in rsync.

### DIFF
--- a/lib/rsync.js
+++ b/lib/rsync.js
@@ -11,7 +11,6 @@ var Buffer = Filer.Buffer;
 var Path = Filer.Path;
 var fsUtils = require('./fs-utils.js');
 var Errors = Filer.Errors;
-var CryptoJS = require('crypto-js');
 var async = require('async');
 var _ = require('lodash');
 var MD5 = require('MD5');

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "async": "^0.9.0",
     "bower": "1.3.8",
     "browser-request": "^0.3.1",
-    "crypto-js": "^3.1.2-3",
     "events": "^1.0.1",
     "express": "3.4.5",
     "filer-fs": "0.1.2",


### PR DESCRIPTION
Nice space saving here--we aren't using it anymore.
