### PR TITLE
let's not use lodash

### DIFF
--- a/lib/lodash-lite.js
+++ b/lib/lodash-lite.js
@@ -1,0 +1,30 @@
+module.exports = {
+  difference: function(arr,farr) {
+    return arr.filter(function(v) {
+      return farr.indexOf(v) === -1;
+    });
+  },
+  sortBy: function(list,prop) {
+    return list.sort(function(a,b) {
+      a = a[prop];
+      b = b[prop];
+      return (a === b) ? 0 : (a < b) ? -1 : 1;
+    });
+  },
+  isArray: Array.isArray || function(obj) {
+    return toString.call(obj) === '[object Array]';
+  },
+  map: function(input, fn) {
+    if (this.isArray(input)) {
+      return input.map(fn);
+    }
+    return Object.keys(input).map(function(v) {
+      return fn(input[v]);
+    });
+  },
+  values: function(obj) {
+    return Object.keys(obj).map(function(v) {
+      return obj[v];
+    });
+  }
+};

--- a/lib/rsync.js
+++ b/lib/rsync.js
@@ -12,11 +12,11 @@ var Path = Filer.Path;
 var fsUtils = require('./fs-utils.js');
 var Errors = Filer.Errors;
 var async = require('./async-lite.js');
-var _ = require('lodash');
 var MD5 = require('MD5');
 var rsync = {};
 var constants = require('./constants.js');
 var conflict = require('./conflict.js');
+var ld_shim = require('./lodash-lite.js');
 
 // Rsync Options that can be passed are:
 // size       -   the size of each chunk of data in bytes that should be checksumed
@@ -705,7 +705,7 @@ rsync.patch = function(fs, path, diff, options, callback) {
     // Determine the node paths for those that were not synced
     // by getting the difference between the paths that needed to
     // be synced and the paths that were synced
-    var failedPaths = _.difference(pathsToSync, paths.synced);
+    var failedPaths = ld_shim.difference(pathsToSync, paths.synced);
     paths.failed = paths.failed.concat(failedPaths);
     callback(err, paths);
   }
@@ -732,7 +732,7 @@ rsync.patch = function(fs, path, diff, options, callback) {
         var srcContents = entryDiff.map(function(element) {
           return element.path;
         });
-        deletedNodes = _.difference(destContents, srcContents);
+        deletedNodes = ld_shim.difference(destContents, srcContents);
       }
 
       function maybeUnlink(item, callback) {
@@ -1010,8 +1010,8 @@ rsync.compareContents = function(fs, checksums, chunkSize, callback) {
     }
 
     // Sort the checksum objects in each array by the 'index' property
-    checksum1 = _.map(_.sortBy(checksum1, 'index'), _.values);
-    checksum2 = _.map(_.sortBy(checksum2, 'index'), _.values);
+    checksum1 = ld_shim.map(ld_shim.sortBy(checksum1, 'index'), ld_shim.values);
+    checksum2 = ld_shim.map(ld_shim.sortBy(checksum2, 'index'), ld_shim.values);
 
     // Compare each object's checksums
     for(var i = 0; i < comparisonLength; i++) {
@@ -1051,7 +1051,7 @@ rsync.compareContents = function(fs, checksums, chunkSize, callback) {
             return callback(err);
           }
 
-          if(!entry.contents || _.difference(entry.contents, nodeList).length) {
+          if(!entry.contents || ld_shim.difference(entry.contents, nodeList).length) {
             return callback(EDIFF);
           }
 

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "habitat": "1.1.0",
     "helmet": "0.2.0",
     "knox": "0.8.9",
-    "lodash": "^2.4.1",
     "messina": "0.1.2",
     "mime": "^1.2.11",
     "newrelic": "1.4.0",


### PR DESCRIPTION
This replaces the 140kb or so lodash with only the shims we use. Which is very, very few. It cuts down the dev version to about 275kb, and the minified version to 107kb. It's an insane amount of win.
