### PR TITLE
Fix issue #383 - Update gruntfile.js

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,5 @@ node_js:
 - '0.10'
 before_install:
 - npm install -g grunt-cli
-before_script:
-- grunt init
 env:
  - "PORT=9090 ALLOWED_CORS_DOMAINS=\"http://localhost:7777\" NODE_ENV=\"development\" ENABLE_GELF_LOGS=false SESSION_SECRET=\"secret value\" FORCE_SSL=false LOGIN_SERVER_URL_WITH_AUTH=\"http://localhost:3000\" ENABLE_PATH_ROUTE=true ENABLE_JSON_ROUTE=true ENABLE_ZIP_ROUTE=true MAX_SYNC_SIZE_BYTES=2000000"

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -155,11 +155,6 @@ module.exports = function(grunt) {
      * Testing & Dev tasks
      */
     exec: {
-      grunt_bower: {
-        command: 'bower install && grunt install',
-        stdout: true,
-        stderr: true
-      },
       run_mocha: {
         command: '"./node_modules/.bin/mocha" --timeout 70000 --recursive --reporter spec ./tests',
         stdout: true,
@@ -226,10 +221,8 @@ module.exports = function(grunt) {
   // Simple multi-tasks
   grunt.registerTask( "test", [ "jshint", "exec:run_mocha" ] );
   grunt.registerTask( "default", [ "test" ] );
-  grunt.registerTask( "init", [ "exec:grunt_bower" ] );
   grunt.registerTask( "build", [ "clean", "browserify:makedriveClient", "uglify" ] );
   grunt.registerTask( "makedriveClient", [ "clean", "browserify:makedriveClient", "uglify:develop" ] );
-  grunt.registerTask( "install", [ "less", "uglify:dependencies", "uglify:angular_app" ] );
   grunt.registerTask( "dev", [ "less", "uglify:angular_app", "build", "express:dev", "watch" ] );
 
   // Complex multi-tasks

--- a/README.md
+++ b/README.md
@@ -30,7 +30,11 @@ $ git clone https://github.com/mozilla/makedrive.git
 
 2) In your MakeDrive directory, install all of the necessary MakeDrive dependencies:
 
-If you don't already have `grunt-cli` installed globally, here is the console command using `npm` -
+If you don't already have `grunt-cli` and `bower` installed globally, here is the console command using `npm` -
+
+```
+$ sudo npm install bower -g
+```
 
 ```
 $ sudo npm install grunt-cli -g
@@ -44,7 +48,7 @@ $ npm install
 
 Next, install dependencies -
 ```
-$ grunt init
+$ bower install
 ```
 
 3) Copy the distributed environment file via command line, or manually using a code editor:

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Webmaker Filesystem",
   "scripts": {
     "start": "node ./server/index.js",
-    "test": "grunt init && grunt test"
+    "test": "grunt test"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
I don't think we need to run `grunt init` anymore since we don't have submodule to update everytime we run the test (`filer`). I also took off `grunt install` because I believe if anyone ever need to work with the front-end demo page they can simply use `grunt dev` for that or `grunt build` everytime they have some changes to angularjs files.
