### PR TITLE
Fix bug with Max size

### DIFF
--- a/server/lib/sync.js
+++ b/server/lib/sync.js
@@ -21,7 +21,7 @@ var ActiveSyncManager = require('../../server/lib/active-sync-manager');
 var connectedClients = {};
 
 var CLIENT_TIMEOUT_MS = env.get('CLIENT_TIMEOUT_MS') || 5000;
-var MAX_SYNC_SIZE_BYTES = env.get('MAX_SYNC_SIZE_BYTES', Math.Infinity);
+var MAX_SYNC_SIZE_BYTES = env.get('MAX_SYNC_SIZE_BYTES') || Math.Infinity;
 
 function Sync(username, id, ws) {
   EventEmitter.call(this);


### PR DESCRIPTION
Apparently we can't use `env.get` to fallback to another value the way we did it, so it was always had an empty value and fail to sync with any file size.
