### PR TITLE
add no_ready_check to redis client

### DIFF
--- a/server/redis-clients.js
+++ b/server/redis-clients.js
@@ -70,14 +70,14 @@ function createClient(callback) {
     redisUrl.password = redisUrl.auth ? redisUrl.auth.split(':')[1] : null;
 
     client = redis.createClient(redisUrl.port, redisUrl.hostname);
+    if(redisUrl.password) {
+      client.auth(redisUrl.password);
+    }
 
     // Caller needs to figure out what to do with errors, hang-ups.
     client.on('error', onerror);
     client.on('end', onend);
     client.on('ready', function() {
-      if(redisUrl.password) {
-        client.auth(redisUrl.password);
-      }
 
       log.info('Connected to redis hostname=%s port=%s', redisUrl.hostname, redisUrl.port);
       callback(null, client);


### PR DESCRIPTION
according to https://github.com/mranney/node_redis#overloading

`no_ready_check:` defaults to false. When a connection is established to the Redis server, the server might still be loading the database from disk. While loading, the server not respond to any commands. To work around this, node_redis has a "ready check" which sends the INFO command to the server. The response from the INFO command indicates whether the server is ready for more commands. When ready, node_redis emits a ready event.

This is actually a trouble when deploying to heroku where we are doing some development on Webmaker app.
