### PR TITLE
Fix #409 - Figure out why old clients are still getting broadcast messages when CLOSED

### DIFF
--- a/server/socket-server.js
+++ b/server/socket-server.js
@@ -9,7 +9,7 @@ module.exports = new EventEmitter();
 
 module.exports.start = function(server, callback) {
   try {
-    wss = new WebSocketServer({server: server});
+    wss = new WebSocketServer({server: server, clientTracking: false});
   } catch(err) {
     log.error(err, 'Could not start Socket Server');
     return callback(err);


### PR DESCRIPTION
The way I was removing redis event handlers is wrong, I have to cache a reference to a function.
