### PR TITLE
Record and log more and better info about connected clients.

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,10 +51,11 @@
     "url": "https://github.com/mozilla/makedrive/issues"
   },
   "dependencies": {
-    "bower": "1.3.8",
     "MD5": "^1.2.1",
     "archiver": "^0.10.1",
+    "bower": "1.3.8",
     "browser-request": "^0.3.1",
+    "bunyan": "^1.1.3",
     "events": "^1.0.1",
     "express": "3.4.5",
     "filer": "0.0.28",
@@ -63,12 +64,12 @@
     "grunt-contrib-less": "^0.11.4",
     "habitat": "1.1.0",
     "helmet": "0.2.0",
-    "bunyan": "^1.1.3",
     "mime": "^1.2.11",
     "newrelic": "1.4.0",
     "node-uuid": "^1.4.1",
     "recluster": "^0.3.7",
     "redis": "^0.12.1",
+    "useragent": "^2.1.0",
     "webmaker-auth": "0.0.14",
     "ws": "^0.4.31"
   },

--- a/server/lib/client-info.js
+++ b/server/lib/client-info.js
@@ -1,0 +1,84 @@
+/**
+ * Client info keyed on client id. Mainly used for logging.
+ * Getting full details about a client is a multi-part process
+ * since we get partial info when they request a token, and more
+ * when they finally connect/authenticate over the web socket.
+ */
+var useragent = require('useragent');
+var log = require('./logger.js');
+
+function ClientInfo(id, userAgentString) {
+  this.id = id;
+
+  // User isn't yet known, we'll update this in update() later
+  this.username = 'unauthenticated';
+
+  // Try to extract useful browser/device info
+  try {
+    var agent = useragent.parse(userAgentString);
+    this.agent = agent.toString();
+    this.device = agent.device.toString();
+  } catch(err) {
+    log.error({err: err}, 'Error parsing user agent string: `%s`', userAgentString);
+    this.agent = "Unknown";
+    this.device = "Unknown";
+  }
+
+  this.born = Date.now();
+
+  // How many times this client has sync'ed during this connection.
+  this.downstreamSyncs = 0;
+  this.upstreamSyncs = 0;
+}
+
+// How long this client has been connected in MS
+ClientInfo.prototype.connectedInMS = function() {
+  return Date.now() - this.born;
+};
+
+/**
+ * Keep track of client info objects while they are still connected.
+ */
+var clients = {};
+
+/**
+ * Step 1: create a partial ClientInfo object when the client requests a token
+ */
+function init(id, userAgentString) {
+  clients[id] = new ClientInfo(id, userAgentString);
+}
+
+/**
+ * Step 2: update the ClientInfo object with all the client info when
+ * web socket connection is completed.
+ */
+function update(client) {
+  var id = client.id;
+
+  // Auto-remove when this client is closed.
+  client.once('closed', function() {
+    remove(id);
+  });
+
+  var info = find(client);
+  if(!info) {
+    log.warn('No ClientInfo object found for client.id=%s', id);
+    return;
+  }
+  info.username = client.username;
+}
+
+function remove(id) {
+  delete clients[id];
+}
+
+function find(client) {
+  return clients[client.id];
+}
+
+module.exports = {
+  init: init,
+  update: update,
+  remove: remove,
+  find: find
+};

--- a/server/lib/client-manager.js
+++ b/server/lib/client-manager.js
@@ -5,6 +5,7 @@ var filesystem = require('./filesystem');
 var Constants = require('../../lib/constants.js');
 var States = Constants.server.states;
 var log = require('./logger.js');
+var ClientInfo = require('./client-info.js');
 
 /**
  * Handle initial connection and authentication, bind user data
@@ -23,6 +24,7 @@ function initClient(client) {
       data = JSON.parse(msg.data);
     } catch(err) {
       log.error({client: client, err: err}, 'Error parsing client token. Data was `%s`', msg.data);
+      ClientInfo.remove(token);
       client.close({
         code: 1011,
         message: 'Error: token could not be parsed.'
@@ -35,6 +37,7 @@ function initClient(client) {
     var username = WebsocketAuth.getAuthorizedUsername(token);
     if (!username) {
       log.warn({client: client}, 'Client sent an invalid or expired token (could not get username): token=%s', token);
+      ClientInfo.remove(token);
       client.close({
         code: 1008,
         message: 'Error: invalid token.'
@@ -49,6 +52,7 @@ function initClient(client) {
       keyPrefix: username,
       name: username
     });
+    ClientInfo.update(client);
 
     log.info({client: client}, 'Client connected');
 

--- a/server/lib/logger.js
+++ b/server/lib/logger.js
@@ -1,5 +1,6 @@
 var bunyan = require('bunyan');
 var env = require('./environment.js');
+var ClientInfo = require('./client-info.js');
 
 var logger = bunyan.createLogger({
   name: 'MakeDrive',
@@ -13,12 +14,35 @@ var logger = bunyan.createLogger({
     },
     // See server/lib/client.js
     client: function clientSerializer(client) {
-      return {
+      var o = {
         username: client.username,
         id: client.id,
         state: client.state,
         path: client.path
       };
+
+      var info = ClientInfo.find(client);
+      if(info) {
+        o.agent = info.agent;
+        o.device = info.device !== 'Other 0.0.0' ? info.device : 'Unknown';
+        o.connectedInMS = info.connectedInMS;
+        o.downstreamSyncs = info.downstreamSyncs;
+        o.upstreamSyncs = info.upstreamSyncs;
+      }
+
+      // If we are holding a lock
+      if(client.lock) {
+        o.lock = true;
+        o.lockAge = client.lock.age;
+      }
+
+      // If we have info about when this client started syncing
+      // calculate how long it has been active
+      if(client._syncStarted) {
+        o.currentSyncDurationInMS = Date.now() - client._syncStarted;
+      }
+
+      return o;
     },
     // See server/lib/sync-lock.js
     syncLock: function syncLockSerializer(lock) {

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -4,6 +4,7 @@ var env = require('../lib/environment');
 var version = require('../../package.json').version;
 var FilerWebServer = require('../lib/filer-www');
 var WebsocketAuth = require('../lib/websocket-auth');
+var ClientInfo = require('../lib/client-info.js');
 
 module.exports = function createRoutes(app) {
 
@@ -45,6 +46,10 @@ module.exports = function createRoutes(app) {
   app.get( "/api/sync", middleware.crossOriginHandler, middleware.authenticationHandler, function( req, res ) {
     var username = req.params.username;
     var token = WebsocketAuth.generateTokenForClient(username);
+
+    // Record info about this connection, which will be updated later
+    // when the user fully authenticates.
+    ClientInfo.init(token, req.headers['user-agent']);
 
     res.json(200, token);
   });


### PR DESCRIPTION
I really have wanted better details in our logs about clients/syncs.  This is a step in that direction:

```
[2014-10-14T16:27:42.838Z]  INFO: MakeDrive/36257 on hospitality-5.local: Client connected
    client: {
      "username": "humphd",
      "id": "49e93bb8-d319-4f07-b0fa-0708e71f4f08",
      "state": "CONNECTING",
      "path": "/",
      "agent": "Chrome 38.0.2125 / Mac OS X 10.6.8",
      "device": "Other 0.0.0",
      "downstreamSyncs": 0,
      "upstreamSyncs": 0
    }
[2014-10-14T16:27:43.706Z]  INFO: MakeDrive/36257 on hospitality-5.local: Completed downstream sync to client in 863 ms
    client: {
      "username": "humphd",
      "id": "49e93bb8-d319-4f07-b0fa-0708e71f4f08",
      "state": "LISTENING",
      "path": "/",
      "agent": "Chrome 38.0.2125 / Mac OS X 10.6.8",
      "device": "Other 0.0.0",
      "downstreamSyncs": 1,
      "upstreamSyncs": 0
    }
```

This adds a `ClientInfo` module that tracks client info by client id, and deals with extracting data about browser/device, how many times we've synced, how long the last sync took, etc.

Later we should probably refactor this a bit to add `SyncInfo` that can track more detailed info about a sync (number of files, size of files, ...).
