### PR TITLE
Fix #389 - use messina wrapped bunyan for logging, so we get GELF support for MoFo devops logging infra.

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "grunt-contrib-less": "^0.11.4",
     "habitat": "1.1.0",
     "helmet": "0.2.0",
+    "messina": "^0.1.2",
     "mime": "^1.2.11",
     "newrelic": "1.4.0",
     "node-uuid": "^1.4.1",

--- a/server/lib/logger.js
+++ b/server/lib/logger.js
@@ -1,9 +1,9 @@
-var bunyan = require('bunyan');
 var env = require('./environment.js');
 var ClientInfo = require('./client-info.js');
+var messina = require('messina'); 
 
-var logger = bunyan.createLogger({
-  name: 'MakeDrive',
+var logger = messina({
+  name: 'MakeDrive-' + (env.get('NODE_ENV') || 'development'),
   serializers: {
     // See lib/syncmessage.js
     syncMessage: function syncMessageSerializer(msg) {

--- a/server/web-server.js
+++ b/server/web-server.js
@@ -24,20 +24,9 @@ var webmakerAuth = new WebmakerAuth({
   domain: env.get('COOKIE_DOMAIN')
 });
 var port = process.env.PORT || env.get('PORT') || 9090;
-var logger;
 var server;
 
-// TODO - figure out how to make this play nicely with lib/logger.js
-// https://github.com/mozilla/makedrive/issues/389
-//if(env.get('ENABLE_GELF_LOGS')) {
-//  logger = require('messina')('MakeDrive-' + (env.get('NODE_ENV') || 'development')));
-//  logger.init();
-//  app.use(logger.middleware());
-//} else {
-//  app.use(express.logger('dev'));
-//}
-
-// General middleware
+app.use(log.middleware());
 app.disable('x-powered-by');
 app.use(function(req, res, next) {
   var d = domain.create();


### PR DESCRIPTION
The messina module wraps bunyan, but adds some extra goodies in terms of pushing logs to a GELF server.  This makes our logging work like the rest of Webmaker's.

In production we could run it like so: `node app.js | messina | bunyan`
