### PR TITLE
Fix #427 - Rsync patch should use rmdir to remove deleted directories

### DIFF
--- a/lib/rsync/patch.js
+++ b/lib/rsync/patch.js
@@ -59,9 +59,20 @@ module.exports = function patch(fs, path, diffList, options, callback) {
   // don't exist upstream yet, since an upstream sync will add them).
   function removeDeletedNodes(path, callback) {
 
-    function maybeUnlink(pathToDelete, callback) {
+    function maybeDelete(pathToDelete, isDir, callback) {
+      if(typeof isDir === 'function') {
+        callback = isDir;
+        isDir = false;
+      }
+
       if(pathsToSync.indexOf(pathToDelete) !== -1) {
         return callback();
+      }
+
+      // Directory
+      if(isDir) {
+        paths.synced.push(pathToDelete);
+        fs.rmdir(pathToDelete, callback);
       }
 
       // Make sure this file isn't unsynced before deleting
@@ -89,7 +100,7 @@ module.exports = function patch(fs, path, diffList, options, callback) {
         }
 
         if(!stats.isDirectory()) {
-          return maybeUnlink(nodePath, callback);
+          return maybeDelete(nodePath, callback);
         }
 
         removeDeletedNodes(nodePath, callback);
@@ -102,7 +113,7 @@ module.exports = function patch(fs, path, diffList, options, callback) {
           return handleError(err, callback);
         }
 
-        maybeUnlink(path, function(err) {
+        maybeDelete(path, true, function(err) {
           if(err) {
             return handleError(err, callback);
           }


### PR DESCRIPTION
need to wait for filer (https://github.com/filerjs/filer/issues/308) to be fixed first for travis to pass
