### PR TITLE
Use url.href instead of url.toString()

### DIFF
--- a/client/src/client-url.js
+++ b/client/src/client-url.js
@@ -1,5 +1,5 @@
 function parse(url) { return new global.URL(url); }
-function format(urlObj) { return urlObj.toString(); }
+function format(urlObj) { return urlObj.href; }
 
 module.exports = {
   parse: parse,


### PR DESCRIPTION
I ran [this test case](http://jsbin.com/vowutasote/edit?js,output) on a chrome/firefox and `url.href` seems to have as much support as `url.toString()`; resolves `url.toString()` not working in fxos 1.3
