### PR TITLE
[#448] Early return if no websockets

### DIFF
--- a/client/src/client-ws.js
+++ b/client/src/client-ws.js
@@ -7,6 +7,8 @@
  * This module gets used by browserify, see package.json
  */
 
+if (!global.WebSocket) return;
+
 global.WebSocket.prototype.on = global.WebSocket.prototype.on || function(event, listener) {
   this.addEventListener(event, listener);
 };


### PR DESCRIPTION
I know this isn't a complete solution to what to do if no websockets exist, but it will prevent makedrive from throwing as long as the `connect` function isn't called and unblock us on #396
