### PR TITLE
Fix #385 - improve server/lib/filesystem.js

### DIFF
--- a/server/lib/client-manager.js
+++ b/server/lib/client-manager.js
@@ -86,10 +86,7 @@ function initClient(client) {
     // Update client details now that he/she is authenticated
     client.id = token;
     client.username = username;
-    client.fs = filesystem.create({
-      keyPrefix: username,
-      name: username
-    });
+    client.fs = filesystem.create(username);
     ClientInfo.update(client);
 
     log.info({client: client}, 'Client connected');

--- a/server/lib/filer-www/index.js
+++ b/server/lib/filer-www/index.js
@@ -11,10 +11,7 @@ var ZIPHandler = require('./zip-handler.js');
 function FilerWebServer(username, res, options) {
   options = options || {};
 
-  var fs = this.fs = filesystem.create({
-    keyPrefix: username,
-    name: username
-  });
+  var fs = this.fs = filesystem.create(username);
 
   // Pick the appropriate handler type to create
   if(options.json) {

--- a/server/lib/filesystem.js
+++ b/server/lib/filesystem.js
@@ -1,50 +1,73 @@
-var Filer = require( "../../lib/filer.js" ),
-    env = require( "./environment" ),
-    providerType = env.get( "FILER_PROVIDER" ) || "filer-fs" ,
-    Provider = require( providerType ),
-    log = require('./logger.js');
+var Filer = require('../../lib/filer.js');
+var env = require('./environment');
+var providerType = env.get('FILER_PROVIDER') || 'filer-fs';
+var Provider = require(providerType);
+var log = require('./logger.js');
 
 var defaults = {};
 
-// TODO: Invalidate FS instance cache to prevent memory leaks
-//       https://github.com/mozilla/makedrive/issues/16
-var cachedFS = {};
+function setupFilerS3() {
+  var bucket = env.get('S3_BUCKET');
+  var key = env.get('S3_KEY');
+  var secret = env.get('S3_SECRET');
 
-if ( providerType === "filer-s3" ) {
-  defaults.bucket = env.get( "S3_BUCKET" );
-  defaults.key = env.get( "S3_KEY" );
-  defaults.secret = env.get( "S3_SECRET");
-} else if ( providerType === "filer-sql" ) {
-  defaults.type = Provider[env.get( "DB_TYPE" )];
-  defaults.url = env.get( "DB_CONNECTION_URL" );
-  defaults.db = {
-    name: env.get( "DB_NAME" ),
-    username: env.get( "DB_USERNAME" ),
-    password: env.get( "DB_PASSWORD" )
-  };
+  if(!(bucket && key && secret)) {
+    log.fatal('Missing filer-s3 env configuration');
+  }
+
+  defaults.bucket = bucket;
+  defaults.key = key;
+  defaults.secret = secret;
+
+  log.debug('Using filer-s3 provider');
 }
 
-module.exports = {
-  clearCache: function( name ) {
-    delete cachedFS[name];
-  },
-  create: function( options ) {
-    // in filer-sql we are expecting option 'user' which is the same as 'options.name'
-    defaults.user = providerType === "filer-sql" ? options.name : "";
-    Object.keys( defaults ).forEach(function( defaultOption ) {
-      options[ defaultOption ] = options[ defaultOption ] || defaults[ defaultOption ];
-    });
+function setupFilerSQL() {
+  var type = env.get('DB_TYPE');
+  var url = env.get('DB_CONNECTION_URL');
+  var dbName = env.get('DB_NAME');
+  var dbUsername = env.get('DB_USERNAME');
+  var dbPassword = env.get('DB_PASSWORD');
 
-    // Reuse filesystems whenever possible
-    if (!cachedFS[options.name]) {
-      cachedFS[options.name] = new Filer.FileSystem({
-        provider: new Provider(options)
-      }, function(err) {
-        if(err) {
-          log.error(err, 'MakeDrive Filesystem Initialization Error: ');
-        }
-      });
-    }
-    return cachedFS[options.name];
+  // Passing a connection url OR db creds are both fine, but one has to be there.
+  if(!(type && (url || (dbName && dbUsername && dbPassword)))) {
+    log.fatal('Missing filer-sql env configuration');
   }
+
+  defaults.type = Provider[type];
+  defaults.url = url;
+  defaults.db = {
+    name: dbName,
+    username: dbUsername,
+    password: dbPassword
+  };
+
+  log.debug('Using filer-sql provider with ' + type);
+}
+
+if(providerType === 'filer-s3') {
+  setupFilerS3();
+} else if(providerType === 'filer-sql') {
+  setupFilerSQL();
+} else {
+  log.debug('Using filer-fs provider');
+}
+
+module.exports.create = function(username) {
+  var options = {
+    username: username,
+    keyPrefix: username
+  };
+
+  // In filer-sql we are expecting option 'user' which is the same as 'options.name'
+  defaults.user = providerType === 'filer-sql' ? username : '';
+  Object.keys(defaults).forEach(function(defaultOption) {
+    options[defaultOption] = options[defaultOption] || defaults[defaultOption];
+  });
+
+  return new Filer.FileSystem({provider: new Provider(options)}, function(err) {
+    if(err) {
+      log.error(err, 'MakeDrive Filesystem Initialization Error');
+    }
+  });
 };

--- a/server/lib/image-finder.js
+++ b/server/lib/image-finder.js
@@ -17,10 +17,7 @@ function getContent(data, currentPath) {
 }
 
 function ImageFinder(username) {
-  this.fs = filesystem.create({
-    keyPrefix: username,
-    name: username
-  });
+  this.fs = filesystem.create(username);
 }
 
 ImageFinder.prototype.find = function(callback) {

--- a/tests/lib/util.js
+++ b/tests/lib/util.js
@@ -60,11 +60,7 @@ app.post('/upload/*', function(req, res) {
   req.on('end', function() {
     fileData = Buffer.concat(fileData);
 
-    var fs = filesystem.create({
-      keyPrefix: username,
-      name: username
-    });
-
+    var fs = filesystem.create(username);
     fs.writeFile(path, fileData, function(err) {
       if(err) {
         res.send(500, {error: err});
@@ -570,10 +566,7 @@ function prepareDownstreamSync(finalStep, username, token, cb){
   // Set up server filesystem
   upload(username, '/' + testFile.name, testFile.content, function() {
     // Set up client filesystem
-    var fs = filesystem.create({
-      keyPrefix: username + "client",
-      name: username + "client"
-    });
+    var fs = filesystem.create(username + 'client');
 
     var socketPackage = openSocket({
       onMessage: function(message) {

--- a/tests/unit/util-tests.js
+++ b/tests/unit/util-tests.js
@@ -294,8 +294,6 @@ describe('Test util.js', function(){
         util.prepareDownstreamSync(username, result.token, function(err, syncData, fs, socketPackage) {
           expect(err).to.not.exist;
           expect(fs).to.exist;
-          expect(fs.name).to.exist;
-          expect(fs.watch).to.exist;
           expect(fs.provider).to.exist;
           util.cleanupSockets(result.done, socketPackage);
         });
@@ -375,8 +373,6 @@ describe('Test util.js', function(){
 
         util.prepareUpstreamSync(username, result.token, function(err, syncData, fs, socketPackage) {
           expect(fs).to.exist;
-          expect(fs.name).to.exist;
-          expect(fs.watch).to.exist;
           expect(fs.provider).to.exist;
           util.upstreamSyncSteps.requestSync(socketPackage, syncData, function(message, cb) {
             message = util.toSyncMessage(message);
@@ -400,8 +396,6 @@ describe('Test util.js', function(){
         util.prepareUpstreamSync(username, result.token, function(err, syncData, fs, socketPackage) {
           expect(err).to.not.exist;
           expect(fs).to.exist;
-          expect(fs.name).to.exist;
-          expect(fs.watch).to.exist;
           expect(fs.provider).to.exist;
           expect(syncData).to.exist;
           expect(syncData.path).to.exist;


### PR DESCRIPTION
Caching these filesystem instances is an optimization without any data to suggest that it's necessary.  I think the risk of keeping long-running connections to DBs and the like open on potentially leaked cached instances is a greater risk.

This patch removes the filesystem instance caching, and always creates new instances.  I've also streamlined the call signature for `filesystem.create()` so it doesn't require deep knowledge of how providers work.

There were some tests failing, which were looking for `fs.name`, `fs.watch` and these are not necessary.  I've removed them.

I've also fixed some code style and added some basic logging.
