### PR TITLE
Fix #439 - report web server port when starting

### DIFF
--- a/server/web-server.js
+++ b/server/web-server.js
@@ -78,8 +78,10 @@ module.exports.start = function(callback) {
   server = http.createServer(app);
   server.listen(port, function(err) {
     if(err) {
+      log.error('Error starting web server', err);
       return callback(err);
     }
+    log.info('Started web server on port %s', port);
     callback(null, server);
   });
 };


### PR DESCRIPTION
This patch adds info about the web server's startup to our default logging (note the second last line below):

```
 $ npm start

> makedrive@0.0.68 start /Users/dave/Sites/repos/makedrive
> node ./server/index.js | ./node_modules/.bin/bunyan

[2014-11-13T19:51:18.919Z]  INFO: MakeDrive-development/15423 on hospitality.local: Enabling /p/* route
[2014-11-13T19:51:18.920Z]  INFO: MakeDrive-development/15423 on hospitality.local: Enabling /j/* route
[2014-11-13T19:51:18.921Z]  INFO: MakeDrive-development/15423 on hospitality.local: Enabling /z/* route
[2014-11-13T19:51:19.056Z]  INFO: MakeDrive-development/15423 on hospitality.local: Connected to redis hostname=localhost port=6379
[2014-11-13T19:51:19.059Z]  INFO: MakeDrive-development/15423 on hospitality.local: Connected to redis hostname=localhost port=6379
[2014-11-13T19:51:19.062Z]  INFO: MakeDrive-development/15423 on hospitality.local: Connected to redis hostname=localhost port=6379
[2014-11-13T19:51:19.065Z]  INFO: MakeDrive-development/15423 on hospitality.local: Started web server on port 9090
[2014-11-13T19:51:19.066Z]  INFO: MakeDrive-development/15423 on hospitality.local: Started Server Worker.
```
