### PR TITLE
Fix #446 - don't pass 404 handler through to other middleware.

### DIFF
--- a/server/middleware.js
+++ b/server/middleware.js
@@ -52,7 +52,7 @@ module.exports = {
     next();
   },
 
-  errorHandler: function( err, req, res, next ) {
+  errorHandler: function(err, req, res, next) {
     if (typeof err === "string") {
       err = new Error(err);
     }
@@ -62,16 +62,15 @@ module.exports = {
       status: err.status ? err.status : 500
     };
 
-    res.status( error.status ).json( error );
+    res.status(error.status).json(error);
   },
 
-  fourOhFourHandler: function( req, res, next ) {
+  fourOhFourHandler: function(req, res, next) {
     var error = {
-      message: "You found a loose thread!",
+      message: "Not Found",
       status: 404
     };
 
-    res.status( error.status ).json( error );
-    next();
+    res.status(error.status).json(error);
   }
 };


### PR DESCRIPTION
Compare to https://github.com/mozilla/MakeAPI/blob/master/lib/middleware.js#L393-L415.  We're trying to set the res status code multiple times by calling next().
