### PR TITLE
Fix #438 - don't use Unix pipes for our commands, use node pipes

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -154,7 +154,17 @@ module.exports = function(grunt) {
      */
     exec: {
       run_mocha: {
-        command: '"./node_modules/.bin/mocha" --timeout 70000 --recursive --reporter spec ./tests | ./node_modules/.bin/bunyan -l fatal',
+        command: 'mocha --timeout 70000 --recursive --reporter spec tests',
+        options: {
+          // Bump the max buffer size for logging output when debugging
+          maxBuffer: 512 * 1024,
+          // Use the env from the process, but alter a few things for logging
+          env: (function(env) {
+            env.LOG_LEVEL = 'fatal';
+            env.NODE_ENV = 'development';
+            return env;
+          }(process.env))
+        },
         stdout: true,
         stderr: true
       }

--- a/README.md
+++ b/README.md
@@ -43,8 +43,14 @@ $ git clone https://github.com/mozilla/makedrive.git
 If you don't already have `grunt-cli` and `bower` installed globally, do so:
 
 ```
-$ sudo npm install bower -g
-$ sudo npm install grunt-cli -g
+$ npm install bower -g
+$ npm install grunt-cli -g
+```
+
+If you're interested in running the tests, also install Mocha globally:
+
+```
+$ npm install mocha -g
 ```
 
 Afterwards, install the npm modules

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.69",
   "description": "Webmaker Filesystem",
   "scripts": {
-    "start": "node ./server/index.js | ./node_modules/.bin/bunyan",
+    "start": "node server/index.js",
     "test": "grunt test",
     "postinstall": "bower install"
   },
@@ -86,6 +86,7 @@
   "devDependencies": {
     "async": "^0.9.0",
     "browserify": "^4.1.8",
+    "bunyan-prettystream": "^0.1.3",
     "chai": "^1.9.1",
     "grunt": "~0.4.1",
     "grunt-browserify": "^3.0.1",

--- a/server/lib/environment.js
+++ b/server/lib/environment.js
@@ -1,5 +1,19 @@
-module.exports = (function() {
-  var habitat = require("habitat");
-  habitat.load( require("path").resolve(__dirname, "../../.env"));
-  return new habitat();
-}());
+// XXX: habitat overwrites process env variables with what's in .env
+// making it impossible to do `LOG_LEVEL=... npm start` and defining
+// a variable just for the lifetime of a command.  Here we check what's
+// on the env first, and fix it if it gets overwritten.
+var LOG_LEVEL = process.env.LOG_LEVEL;
+
+var habitat = require('habitat');
+habitat.load(require('path').resolve(__dirname, '../../.env'));
+var env = new habitat();
+
+// Fix-up LOG_LEVEL if present on env and different than habitat's
+if(LOG_LEVEL) {
+  var hLOG_LEVEL = env.get('LOG_LEVEL');
+  if(hLOG_LEVEL && hLOG_LEVEL !== LOG_LEVEL) {
+    env.set('LOG_LEVEL', LOG_LEVEL);
+  }
+}
+
+module.exports = env;

--- a/server/lib/logger.js
+++ b/server/lib/logger.js
@@ -1,8 +1,21 @@
 var env = require('./environment.js');
 var messina = require('messina'); 
+var PrettyStream = require('bunyan-prettystream');
+var NODE_ENV = env.get('NODE_ENV') || 'development';
+
+// In development, we pretty print the JSON logging to stdout.
+var stream;
+if(NODE_ENV === 'development') {
+  stream = new PrettyStream();
+  stream.pipe(process.stdout);
+} else {
+  stream = process.stdout;
+}
 
 var logger = messina({
-  name: 'MakeDrive-' + (env.get('NODE_ENV') || 'development'),
+  name: 'MakeDrive-' + NODE_ENV,
+  stream: stream,
+  level: env.get('LOG_LEVEL') || 'info',
   serializers: {
     // See lib/syncmessage.js
     syncMessage: function syncMessageSerializer(msg) {
@@ -58,10 +71,5 @@ var logger = messina({
     }
   }
 });
-
-// Figure out which log level to use. This can be set
-// via command env variables or in .env. Use 'debug'
-// for useful development logs.
-logger.level(env.get('LOG_LEVEL') || 'info');
 
 module.exports = logger;


### PR DESCRIPTION
This fixes `npm start` and `npm test` so you don't need to use a pipe at all.  It also fixes a bug in habitat, where you can't overwrite a variable in your `env` with something in the environment.
